### PR TITLE
Continue previous conversation discussion

### DIFF
--- a/docs/development-tools/honorable-mentions/README.md
+++ b/docs/development-tools/honorable-mentions/README.md
@@ -2,13 +2,30 @@
 
 This section highlights tools that offer excellent value for developers seeking free or cost-effective alternatives to implement vibecoding workflows. While these tools may not have the same polish or feature completeness as my main stack, they provide solid foundations for getting started without financial commitment.
 
-## Tools
+## Free & Cost-Effective Tools
 
 - **[Qwen Coder / Qwen CLI](qwen-coder.md)** - Alibaba's free, open-source coding assistant with MCP support
 - **[Gemini CLI](gemini-cli.md)** - Google's CLI with generous free tier and strong reasoning
 - **[AmpCode](ampcode.md)** - Free tier coding assistance with MCP support
 - **[TRAE](trae.md)** - Cost-effective prompt-based pricing model
 - **[Windsurf](windsurf.md)** - VS Code fork with integrated AI, free models and affordable paid tiers
+
+## Tools I Dropped — Honest Assessments
+
+These are tools I personally used in production and decided to drop from my workflow. I'm including them in honorable mentions because they're worth knowing about, and my experience can help you make informed decisions.
+
+- **[Traycer.ai](traycer.md)** - AI-powered development planning and validation (dropped: too slow, costly, frustration with hallucinations)
+- **[Claude Subscription](claude-subscription.md)** - Premium AI model access via Claude Code CLI (dropped: prohibitive cost, now using GLM with same CLI)
+- **[GitHub Speckit](github-speckit.md)** - GitHub's native specification tool (dropped: too heavyweight for fast-paced vibecoding, prefer OpenSpec)
+
+### Why Share Dropped Tools?
+These tools aren't failures—they're valuable products that didn't fit my specific vibecoding workflow. By sharing honest assessments based on real production experience, I can help you:
+- **Avoid costly mistakes**: Learn from my experience before investing money and time
+- **Make informed choices**: Understand the trade-offs between different approaches
+- **Find better alternatives**: Discover more cost-effective or faster solutions
+- **Recognize use cases**: Some of these tools might be perfect for your specific needs even if they didn't fit mine
+
+The goal is transparency: showing not just what works, but also what I tried and why I moved on.
 
 ## Why These Tools Matter
 

--- a/docs/development-tools/honorable-mentions/claude-subscription.md
+++ b/docs/development-tools/honorable-mentions/claude-subscription.md
@@ -1,0 +1,47 @@
+# Claude Subscription (with Claude Code CLI)
+
+## Overview
+Claude Code is Anthropic's official CLI coding assistant that can be powered by either Claude's subscription plans or alternative model providers. This entry discusses the Claude subscription service specifically—the paid plans that provide access to Anthropic's Claude models through the Claude Code CLI tool.
+
+## Key Strengths
+- **State-of-the-Art Performance**: When working well, Claude delivers exceptional model performance that few alternatives can match
+- **Seamless Ecosystem Integration**: Works flawlessly within Claude's ecosystem with reliable API and infrastructure
+- **Quick Prototyping**: Excellent for rapid prototyping when you need the absolute best model performance
+- **Reliable Infrastructure**: Robust API with strong uptime and consistent performance
+- **Advanced Reasoning**: Superior understanding of complex codebases and architectural patterns
+- **Official Tool Integration**: Claude Code CLI provides excellent developer experience
+
+## Best Use Cases
+- Projects where absolute best-in-class AI performance is non-negotiable
+- Rapid prototyping of complex features requiring strong reasoning
+- Teams already invested in the Claude ecosystem
+- Well-funded projects where cost is less of a concern
+- Developers who need the highest quality code generation and can justify the investment
+
+## Limitations
+- **Performance Degradation**: Notable decline in Claude's capabilities around August 2025
+- **Reduced Limits**: Weekly allowances decreased after initial setup, affecting consistency
+- **Prohibitive Cost**: For serious development (few hours per day, 5 days/week), requires at least Max5 plan at $100/month (~€120 in EU with VAT)
+- **Insufficient Limits**: Even Max20 sometimes isn't enough for intensive development sessions
+- **Cost-Effectiveness**: The cost-to-benefit ratio doesn't favor it compared to open-source alternatives
+- **Diminishing Returns**: With proper vibecoding techniques, the quality gap between Claude and good open-source models becomes negligible
+
+## Why I Dropped It
+After extensive use of Claude subscription in production workflows, I found that while the model quality is excellent, the cost structure is untenable for regular development work. The pricing tiers are designed for casual use, not professional full-time development. More importantly, with proper vibecoding techniques and a solid workflow around any capable LLM, the practical quality difference between Claude and good open-source models (like GLM) becomes minimal, while the cost difference remains massive.
+
+**Important note**: I still use Claude Code CLI tool itself—it's an excellent interface. I just switched from Claude's subscription to GLM Coding Plan as the model provider. The CLI tool remains valuable; it's the Claude subscription pricing that became untenable.
+
+**The verdict**: If you desperately need SOTA model performance, Claude subscription might be worth it, but the cost is prohibitive for most developers. Using Claude Code CLI with GLM Coding Plan provides significantly better monthly profit margins while delivering comparable results when paired with proper vibecoding workflows.
+
+## Alternative Recommendation
+For most developers, especially those doing professional development work:
+- **Keep using Claude Code CLI**: It's an excellent tool with great developer experience
+- **Switch to GLM Coding Plan**: Use it as the model provider instead of Claude subscription
+- **Cost savings**: Save hundreds of dollars monthly while maintaining quality
+- **Better economics**: Redirect savings toward other tools or infrastructure that provide better ROI
+
+The key insight is that vibecoding technique and workflow matter more than raw model performance once you pass a certain quality threshold—and modern open-source models like GLM clear that bar while being far more cost-effective.
+
+**Official Resources**: [claude.ai](https://claude.ai) | [Claude Code CLI](https://github.com/anthropics/claude-code)
+
+Back: [Honorable Mentions](README.md)

--- a/docs/development-tools/honorable-mentions/github-speckit.md
+++ b/docs/development-tools/honorable-mentions/github-speckit.md
@@ -1,0 +1,51 @@
+# GitHub Speckit
+
+## Overview
+GitHub Speckit is GitHub's native specification tool designed to help developers create comprehensive project specifications and manage development workflows. It integrates directly with GitHub repositories and provides structured approaches to project planning and execution.
+
+## Key Strengths
+- **Excellent for New Projects**: Outstanding tool for kickstarting new projects from scratch with clean, well-structured foundations
+- **Recent Improvements**: After recent updates, shows promising capabilities for vibecoding workflows
+- **Clean Architecture**: Forces good practices and creates well-organized project structures
+- **Ideal for Complex Projects**: Solid choice for complex, large-scale projects with many different features
+- **Branch-Based Workflow**: Enforces best practices by requiring branch-based development workflows
+- **Native Integration**: Seamless integration with GitHub's ecosystem
+
+## Best Use Cases
+- Starting new projects from scratch that need solid architectural foundations
+- Large-scale initiatives with multiple features and complex requirements
+- Collaborative projects where structure and organization are paramount
+- Teams that value comprehensive specifications over rapid iteration
+- Projects where clean, well-documented architecture is a priority
+
+## Limitations
+- **Overly Complex Specifications**: Creates unnecessarily complicated specs for simple projects
+- **Slower Workflow**: Way more complex compared to OpenSpec for rapid development
+- **Integration Difficulties**: Not easily integrated with existing projects and repositories
+- **Pace Mismatch**: Better suited for larger-scale initiatives, but too heavyweight for fast-paced, vibe-led development
+- **Learning Curve**: Requires investment to understand and use effectively
+- **Flexibility Trade-off**: Rigid structure can hinder rapid experimentation
+
+## Why I Dropped It
+After using GitHub Speckit in various projects, I found that while it excels at creating comprehensive specifications for new projects, it doesn't align well with fast-paced vibecoding workflows. The tool adds complexity and overhead that slows down iteration speed. For existing projects, integration is challenging and often not worth the effort. OpenSpec emerged as the clear winner for my workflow needs.
+
+**The verdict**: While GitHub Speckit definitely has value, especially for collaborative projects or larger initiatives, OpenSpec is significantly faster to use and enables rapid progression through development tasks. Additionally, OpenSpec can be easily integrated into existing projects and repositories, whereas GitHub Speckit makes this integration challenging.
+
+## When to Use GitHub Speckit Instead
+Despite dropping it from my main workflow, GitHub Speckit remains valuable for:
+- **Green-field projects**: Starting entirely new projects where comprehensive planning is valuable
+- **Large teams**: Collaborative environments where everyone needs clear, structured specifications
+- **Complex systems**: Projects with intricate architectures requiring detailed documentation
+- **Formal processes**: Organizations that require comprehensive spec documentation
+
+## Alternative Recommendation
+For fast-paced vibecoding workflows:
+- **OpenSpec**: Provides the speed and flexibility needed for rapid development
+- **Easy integration**: Works seamlessly with existing projects
+- **Lighter weight**: Less overhead while maintaining quality
+
+Note: These tools have different strengths. GitHub Speckit is more comprehensive but slower; OpenSpec is faster but less formal. Choose based on your project's needs and pace.
+
+**Official Resources**: [GitHub Speckit](https://github.com/)
+
+Back: [Honorable Mentions](README.md)

--- a/docs/development-tools/honorable-mentions/traycer.md
+++ b/docs/development-tools/honorable-mentions/traycer.md
@@ -1,0 +1,38 @@
+# Traycer.ai
+
+## Overview
+Traycer.ai is an AI-powered development planning and validation tool designed to help developers create comprehensive project plans and automatically validate ongoing development work. It integrates with VS Code and its derivatives to provide continuous quality assurance during the development process.
+
+## Key Strengths
+- **Automatic Validation**: Continuously validates your ongoing development work against the project plan
+- **High Output Quality**: When it works correctly, produces high-quality code and architectural decisions
+- **Quality Improvement Cycle**: The combination of plan + validation + improvements after validation generally improves overall project quality
+- **Structured Approach**: Forces developers to think through architecture and planning before implementation
+
+## Best Use Cases
+- Large-scale projects where quality is more important than speed
+- Teams that prioritize thorough validation over rapid iteration
+- Projects with complex architectural requirements
+- Developers willing to invest time upfront for long-term quality gains
+
+## Limitations
+- **Performance Issues**: Planning takes long, validation even longer, and fixes take the longest
+- **Plugin Dependency**: Requires VS Code or its derivatives (no Zed support as of this writing)
+- **Costly**: $25/month for realistic workloads, and recent pricing changes (1 artifact per 45 minutes) may not be enough for serious, fast-paced development
+- **Frustration Factor**: When the plan hallucinates, rollbacks waste significant amounts of time
+- **Speed vs Quality Tradeoff**: Quality comes at the cost of significantly longer delivery time
+
+## Why I Dropped It
+After using Traycer.ai in production, I found that while the quality improvements were real, the time cost was too high for my vibecoding workflow. The tool's slowness became a bottleneck, and when plans hallucinated, the time spent on rollbacks negated the quality benefits. Additionally, the cost structure ($25/month with recent limits) makes it prohibitive for fast-paced development.
+
+**The verdict**: You can achieve similar results with OpenSpec + GLM for a fraction of the price—and often in less time—than with Traycer.
+
+## Alternative Recommendation
+For developers who value the planning and validation approach but need better speed and cost efficiency, consider using:
+- **OpenSpec** for specification and planning
+- **GLM** for code generation and validation
+- This combination delivers comparable quality at a fraction of the cost and time investment
+
+**Official Resources**: [traycer.ai](https://traycer.ai)
+
+Back: [Honorable Mentions](README.md)


### PR DESCRIPTION
- Add traycer.md: AI planning/validation tool (dropped: slow, costly)
- Add claude-subscription.md: Premium AI access (dropped: cost, now using GLM)
- Add github-speckit.md: GitHub spec tool (dropped: too heavyweight for vibecoding)
- Update README.md: Add "Tools I Dropped" section with transparency rationale

Each tool includes detailed experience-based assessment, limitations, and alternative recommendations.