### PR TITLE
Add Octofriend tool to project

### DIFF
--- a/docs/development-tools/honorable-mentions/README.md
+++ b/docs/development-tools/honorable-mentions/README.md
@@ -9,6 +9,7 @@ This section highlights tools that offer excellent value for developers seeking 
 - **[AmpCode](ampcode.md)** - Free tier coding assistance with MCP support
 - **[TRAE](trae.md)** - Cost-effective prompt-based pricing model
 - **[Windsurf](windsurf.md)** - VS Code fork with integrated AI, free models and affordable paid tiers
+- **[Octofriend](octofriend.md)** - Open-source CLI with seamless Synthetic.new integration, excellent MCP support, and no rate limit headaches
 
 ## Tools I Dropped — Honest Assessments
 

--- a/docs/development-tools/honorable-mentions/octofriend.md
+++ b/docs/development-tools/honorable-mentions/octofriend.md
@@ -1,0 +1,58 @@
+# Octofriend
+
+## Overview
+Octofriend is an open-source, privacy-focused CLI coding assistant from Synthetic Lab that integrates seamlessly with the [Synthetic.new subscription](../../ai-model-providers/synthetic-new.md). It's designed as a "small, helpful, zero-telemetry, cephalopod-flavored coding assistant" that brings the power of AI-assisted development to your terminal without compromising on privacy or breaking the bank.
+
+## Key Strengths
+- **Seamless Synthetic.new Integration**: Works perfectly with the Synthetic.new subscription, providing access to 20+ frontier models with competitive pricing
+- **Zero Telemetry & Privacy-First**: No data collection means your code stays completely private
+- **Excellent MCP Server Support**: Easy configuration for Model Context Protocol servers through simple JSON5 configuration
+- **Multi-LLM Flexibility**: Supports OpenAI-compatible and Anthropic-compatible APIs with mid-conversation model switching
+- **No Rate Limit Headaches**: Combined with Synthetic.new, avoids the typical Claude subscription problems (5-hour and weekly rate limits)
+- **Quick Setup**: Enables rapid creation of a no-code or low-code development environment on your local machine
+- **Thinking Model Optimization**: Specially designed to work effectively with advanced models like GPT-5 and Claude 4
+- **Docker Integration**: Built-in support for containerized development environments
+- **Flexible Operation Modes**: Choose between guided (with confirmations) or "unchained" (no-confirmation) modes
+
+## Best Use Cases
+- Developers seeking a privacy-first alternative to mainstream AI coding assistants
+- Users wanting seamless integration between their CLI tool and subscription service (similar to Claude Code + Claude subscription but with better rate limits)
+- Budget-conscious developers who want premium AI assistance without prohibitive costs
+- Teams requiring zero-telemetry tools for sensitive codebases
+- Developers who want to experiment with multiple frontier models from a single subscription
+- Quick prototyping and no-code/low-code local development workflows
+
+## The Synthetic.new + Octofriend Combination
+
+When paired with a [Synthetic.new subscription](../../ai-model-providers/synthetic-new.md), Octofriend delivers exceptional value:
+
+### Pricing Advantage
+- **$20/month Standard Plan**: 135 messages every 5 hours (3x higher than Claude's $20 plan)
+- **$60/month Pro Plan**: 1,350 messages every 5 hours (10x higher rate limits)
+- No weekly limits, only 5-hour windows
+- Access to 20+ frontier open-source models included
+
+### Integration Benefits
+- All the convenience of Claude Code + Claude subscription integration
+- None of the usual Claude subscription headaches (rate limits, weekly caps)
+- Privacy-first approach - no concerns about code privacy
+- Lightning-fast performance (up to 200 tokens/second with models like GLM-4.6)
+- Single provider for multiple cutting-edge models
+
+### Quick Local Development
+The combination enables developers to rapidly set up a fully functional AI-assisted development environment locally, with seamless MCP server integration and access to frontier models—all while maintaining complete code privacy.
+
+## Limitations
+- **Not as Advanced**: May lack some polish or advanced features compared to Droid CLI or Claude Code CLI
+- **Newer Ecosystem**: Being open-source and community-driven, it may have a smaller ecosystem than established commercial alternatives
+- **Requires Configuration**: MCP server setup requires manual JSON5 configuration (though it's straightforward)
+- **Command-line Only**: Terminal-based interface may not suit developers preferring GUI-based tools
+
+## Why It Matters
+Octofriend represents a compelling middle ground in the vibecoding landscape: it's pleasant to use, offers excellent value for money, and solves real pain points that plague other solutions (rate limits, privacy concerns, cost). While it may not have all the bells and whistles of more advanced CLIs, its seamless integration with Synthetic.new creates a developer experience that rivals premium offerings—at a fraction of the cost and without the usual frustrations.
+
+For developers who prioritize privacy, value, and a smooth integration between their tools and subscription service, Octofriend combined with Synthetic.new delivers a no-code/low-code workflow that just works—making it genuinely worth an honorable mention among vibecoding tools.
+
+**Official Resources**: [GitHub Repository](https://github.com/synthetic-lab/octofriend) | [Synthetic.new](https://synthetic.new/?referral=IDyp75aoQpW9YFt)
+
+Back: [Honorable Mentions](README.md)


### PR DESCRIPTION
Add octofriend as a new honorable mention under free & cost-effective tools. Octofriend is an open-source CLI coding assistant that integrates seamlessly with Synthetic.new subscription, offering excellent MCP server support, zero telemetry, and a privacy-first approach without the typical rate limit headaches of other solutions.

Key highlights:
- Seamless integration with Synthetic.new subscription models
- Zero telemetry and privacy-first design
- Excellent MCP server support
- No rate limit frustrations (compared to Claude subscription)
- Enables quick local no-code/low-code development setup
- Pleasant to use with good value proposition