### PR TITLE
Add entry for Cline, Roo Code, and Kilo Code

### DIFF
--- a/docs/development-tools/honorable-mentions/README.md
+++ b/docs/development-tools/honorable-mentions/README.md
@@ -17,6 +17,7 @@ These are tools I personally used in production and decided to drop from my work
 
 - **[Traycer.ai](traycer.md)** - AI-powered development planning and validation (dropped: too slow, costly, frustration with hallucinations)
 - **[GitHub Speckit](github-speckit.md)** - GitHub's native specification tool (dropped: too heavyweight for fast-paced vibecoding, prefer OpenSpec)
+- **[Cline / Roo Code / Kilo Code](cline-roo-kilo.md)** - VSCode plugins for GUI-based vibecoding with GLM/Synthetic.new integration (dropped: unnecessary complexity, tool/MCP call reliability issues)
 
 ### Why Share Dropped Tools?
 These tools aren't failures—they're valuable products that didn't fit my specific vibecoding workflow. By sharing honest assessments based on real production experience, I can help you:

--- a/docs/development-tools/honorable-mentions/cline-roo-kilo.md
+++ b/docs/development-tools/honorable-mentions/cline-roo-kilo.md
@@ -1,0 +1,52 @@
+# Cline / Roo Code / Kilo Code
+
+## Overview
+Cline, Roo Code, and Kilo Code are VSCode plugins for AI-assisted coding, with Roo Code and Kilo Code being forks of the original Cline project. These tools bring vibecoding capabilities directly into Visual Studio Code through a GUI-based interface, making AI-assisted development accessible without leaving your familiar editor. They're commonly used across the vibecoding industry and are known for rapid development cycles with frequent updates.
+
+## Key Strengths
+- **Seamless VSCode Integration**: Work within your existing editor without switching contexts
+- **GUI-Based Vibecoding**: User-friendly interface for AI interactions, perfect for developers preferring visual workflows
+- **Fast Development Pace**: All three tools are actively developed with frequent updates and new features
+- **Provider Integration**: Seamless integration with [GLM Coding Plan](../../ai-model-providers/glm-coding-plan.md) and [Synthetic.new](../../ai-model-providers/synthetic-new.md) subscriptions
+- **Plugin Ecosystem**: Access to VSCode's extensive plugin library alongside AI capabilities
+- **Multiple Forks**: Three actively maintained variants give users choice based on specific features or development direction
+
+## Limitations / Current Issues
+- **Unnecessary Complexity**: Add layers of abstraction that aren't needed for standard vibecoding workflows
+- **Tool Call Challenges**: Experience issues with tool calls, particularly when complexity increases
+- **MCP Reliability**: MCP (Model Context Protocol) calls can be problematic if the MCP server isn't super common or well-established
+- **Workflow Friction**: The added complexity can slow down fast-paced vibecoding workflows rather than enhance them
+- **GUI Overhead**: While the GUI is nice, it can introduce unnecessary steps compared to direct CLI interactions
+
+## Best Use Cases
+- Developers who prefer working exclusively within VSCode
+- Teams already standardized on Visual Studio Code who want to add AI capabilities
+- Users who value GUI-based interactions over CLI workflows
+- Developers with existing GLM Coding Plan or Synthetic.new subscriptions looking for tight integration
+- Projects where the VSCode extension ecosystem is critical
+
+## Who Should Consider Alternatives
+- **Fast-paced vibecoding practitioners**: The added complexity can slow down workflows that benefit from direct, streamlined interactions
+- **MCP-heavy workflows**: If you rely on less common or custom MCP servers, expect reliability issues
+- **CLI-first developers**: If you prefer command-line tools, the GUI overhead may feel unnecessary
+- **Simplicity seekers**: Developers who value minimal abstraction layers between themselves and the AI
+
+## Why I Dropped Them
+I used all three of these tools (Cline, Roo Code, and Kilo Code) for extended periods in my workflow. While they're well-crafted and popular in the vibecoding community, I ultimately moved away from them because:
+
+1. **Complexity vs. Value**: They add architectural layers that aren't necessary for standard vibecoding. The GUI and plugin infrastructure introduce overhead without proportional benefits for my fast-paced workflow.
+
+2. **Tool Call Reliability**: As work complexity increased, these tools struggled with consistent tool call execution, leading to frustrating debugging sessions.
+
+3. **MCP Integration Pain**: When working with custom or less common MCP servers, the reliability dropped significantly. The tools work great with popular MCPs but struggle otherwise.
+
+4. **Workflow Speed**: The GUI-based approach, while visually appealing, added friction to my workflow compared to direct CLI interactions.
+
+That said, these are genuinely popular tools in the vibecoding industry for good reason—they make AI-assisted coding accessible within VSCode and have strong integration with major providers. They just didn't align with my specific workflow preferences for speed and simplicity.
+
+## Official Resources
+- **Cline**: [github.com/cline/cline](https://github.com/cline/cline)
+- **Roo Code**: [github.com/RooVetGit/Roo-Cline](https://github.com/RooVetGit/Roo-Cline)
+- **Kilo Code**: Check VSCode marketplace for latest information
+
+Back: [Honorable Mentions](README.md)


### PR DESCRIPTION
Added comprehensive entry covering three VSCode plugin tools (Cline, Roo Code, and Kilo Code) that are forks of the same project. The entry includes:
- Overview of GUI-based vibecoding within VSCode
- Seamless integration with GLM Coding Plan and Synthetic.new
- Honest assessment of strengths and limitations
- Explanation of why these commonly-used tools were dropped from the workflow (unnecessary complexity, tool/MCP call reliability issues)