### PR TITLE
Add GitHub Copilot to honorable mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Especially in the world of frontier models being **expensive** - usually it make
   - **Tools I Dropped**: Traycer • GitHub Speckit
 - [AI Model Providers 🤖](docs/ai-model-providers/README.md)
   - **Primary Providers**: GLM Coding Plan • Factory AI • Synthetic.new
-  - **Honorable Mentions**: Budget platforms (Chutes.ai • OpenRouter) • Over-expensive options (Claude Subscription)
+  - **Honorable Mentions**: GitHub Copilot • Budget platforms (Chutes.ai • OpenRouter) • Over-expensive options (Claude Subscription)
 - [Core Technologies 🧰](docs/core-technologies.md)
   - Astro • Tailwind CSS • Cloudflare Pages
 - [Context Management 🧠](docs/context-management/README.md)

--- a/docs/ai-model-providers/honorable-mentions/README.md
+++ b/docs/ai-model-providers/honorable-mentions/README.md
@@ -18,6 +18,9 @@ However, they all share common limitations that prevent me from recommending the
 
 ## The Providers
 
+### Value & Native Integration
+- **[GitHub Copilot](github-copilot.md)** - Good value at $10 for 300 prompts + unlimited GPT-4o-mini; free for students; VS Code native but limited for heavy vibecoding
+
 ### Budget & Experimentation Platforms
 - **[Chutes.ai](chutes.ai.md)** - Extremely affordable but unreliable; good for learning, not for production
 - **[OpenRouter](openrouter.md)** - Massive model selection with free tier; great for exploration but inconsistent reliability

--- a/docs/ai-model-providers/honorable-mentions/github-copilot.md
+++ b/docs/ai-model-providers/honorable-mentions/github-copilot.md
@@ -1,0 +1,62 @@
+# GitHub Copilot
+
+## Overview
+GitHub Copilot is a VS Code native AI coding assistant that offers solid value, particularly for students (who can access it for free) and developers who prefer IDE-integrated solutions. While there are better agents and cheaper vibecoding options available, Copilot provides a reliable, straightforward coding experience with one standout feature: unlimited GPT-4o-mini access.
+
+## Key Strengths
+- **Excellent Value**: 300 prompts for $10/month is competitive pricing
+- **Free for Students**: If you're eligible for student access, this is an outstanding deal
+- **GPT-4o-mini Unlimited**: Unlimited access to GPT-4o-mini for fast-paced development and small changes
+- **VS Code Native**: Deep integration with Visual Studio Code, no context switching required
+- **Reliable**: Consistent uptime and performance from GitHub's infrastructure
+- **Not Overly Complicated**: Straightforward interface without excessive complexity
+- **Main Models Available**: Hosts the primary important models you'd want access to
+- **Good Vibecoding Capability**: Allows significant AI-assisted development within limits
+
+## Limitations
+- **Prompt Limits**: Capped at 300 prompts per month (anxiety-inducing if you're a heavy user)
+- **Not Ideal for CLI-First Workflows**: Best suited for IDE users, less optimal for CLI-based development
+- **Limited Full-Project Development**: GPT-4o-mini won't develop entire projects in one shot
+- **Better Alternatives Exist**: Other agents and deals offer more for serious vibecoding work
+
+## GPT-4o-mini: The Hidden Gem
+The unlimited GPT-4o-mini access is Copilot's strongest feature:
+- **Fast**: Quick responses for rapid iteration
+- **Good for Fixes**: Excellent at debugging and small fixes
+- **Small Changes**: Perfect for incremental improvements
+- **Single Tool Convenience**: Everything in one $10 subscription within VS Code
+
+While it won't architect and build full applications end-to-end, for fixing issues, making targeted improvements, and quick development tasks, unlimited GPT-4o-mini is genuinely useful.
+
+## Best Use Cases
+- **Students**: If you qualify for free access, this is a no-brainer
+- **VS Code Enthusiasts**: Perfect if you live in Visual Studio Code and want native integration
+- **Budget-Conscious Developers**: $10/month for 300 prompts + unlimited GPT-4o-mini is solid value
+- **Quick Fixes & Small Changes**: Ideal when you need fast, reliable assistance without switching tools
+- **Learning**: Good entry point to AI-assisted development in a familiar environment
+
+## Who Should Consider Alternatives
+- **CLI-First Developers**: If you primarily work via command-line agents, other solutions fit better
+- **Heavy Vibecoding Users**: 300 prompts/month creates anxiety if you code heavily with AI
+- **Full-Project Builders**: Better agents exist for developing complete applications
+- **Unlimited-Seekers**: Platforms like [Synthetic.new](../synthetic-new.md) (135 prompts per 5 hours using quality open-source models) or other providers offer different trade-offs
+
+## Recommendation
+GitHub Copilot occupies an interesting middle ground:
+- Not the cheapest vibecoding solution available
+- Not the most powerful agent for full-project development
+- Not the best choice for CLI-heavy workflows
+
+**However**, it excels at being:
+- A reliable, simple, VS Code-native tool
+- Excellent value for students (free) and budget-conscious developers ($10/month)
+- The only $10 subscription giving you unlimited GPT-4o-mini access in your editor
+
+**Bottom Line**: If you're a student, get it (it's free). If you want a straightforward VS Code native agent and don't need unlimited heavy vibecoding, it's a solid choice. If you're building entire projects regularly via CLI agents or need unlimited usage without prompt anxiety, look at other options in the main [AI Model Providers](../README.md) section.
+
+## Personal Note
+I used Copilot quite often and found it valuable, but ultimately moved away because I work primarily via CLI agents and dislike the anxiety of monthly/weekly prompt limits. For my workflow, services like [Synthetic.new](../synthetic-new.md) offering time-based limits (135 prompts per 5 hours) with quality open-source models fit better. But if you're in VS Code all day and want something that "just works" without complexity, Copilot delivers.
+
+**Official Resources**: [GitHub Copilot](https://github.com/features/copilot)
+
+Back: [Honorable Mentions](README.md)


### PR DESCRIPTION
- Created comprehensive GitHub Copilot article highlighting:
  - Excellent value: 300 prompts for $10/month + unlimited GPT-4o-mini
  - Free for students (outstanding deal)
  - VS Code native integration
  - Good for fixes and small changes, limited for full-project development
  - Better alternatives exist for heavy vibecoding and CLI workflows
- Updated honorable mentions README with new "Value & Native Integration" category
- Added GitHub Copilot to main README summary