### PR TITLE
Review repository for clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Especially in the world of frontier models being **expensive** - usually it make
 - [Honorable Mentions 🏆](docs/development-tools/honorable-mentions/README.md)
   - **Free & Cost-Effective**: Qwen Coder • Gemini CLI • AmpCode • TRAE • Octofriend
   - **Native Integration**: GitHub Copilot
-  - **Tools I Dropped**: Traycer • GitHub Speckit
+  - **Tools I Dropped**: Traycer • GitHub Speckit • Cline • Roo Code • Kilo Code (VSCode plugins)
 - [AI Model Providers 🤖](docs/ai-model-providers/README.md)
   - **Primary Providers**: GLM Coding Plan • Synthetic.new
   - **Honorable Mentions**: Budget platforms (Chutes.ai • OpenRouter • nanoGPT • Factory AI) • Over-expensive options (Claude Subscription)
@@ -111,8 +111,8 @@ Tip: Keep context lean. Link only relevant files in your prompts and use MCPs (e
 ## 🫶 Support the Author
 
 If you've found this guide helpful and want to support my work, consider using these referral links for the tools I recommend:
-- **[Synthetic.new](https://synthetic.new/?referral=IDyp75aoQpW9YFt)** - Generous, 5h limit, privacy-first AI provider with extensive open-sourcemodel library and competitive pricing ($10 first month on standard plan)
-- **[GLM Coding Plan](https://z.ai/subscribe?ic=CUEFJ9ALMX)** - Cheap and reliable provider of a coding plan with generous 5h limit and GLM model(s) support
+- **[Synthetic.new](https://synthetic.new/?referral=IDyp75aoQpW9YFt)** - Privacy-first AI provider with 20+ frontier models. Standard plan $20/mo (save $10 with referral link), Pro $60/mo (save $20 with referral link)
+- **[GLM Coding Plan](https://z.ai/subscribe?ic=CUEFJ9ALMX)** - Cost-effective provider with generous 5h usage windows. Lite $3/mo (most users), Pro $15/mo (heavy usage). [Check current pricing](https://z.ai/subscribe?ic=CUEFJ9ALMX)
 
 
 Using these links helps me continue maintaining and expanding this guide while you get access to excellent tools. No pressure though - the guide will always remain free and open source! ⭐

--- a/docs/ai-model-providers/README.md
+++ b/docs/ai-model-providers/README.md
@@ -11,23 +11,34 @@ A curated selection of AI model providers and services optimized for vibecoding 
 - **[Synthetic.new](./synthetic-new.md)** — Privacy-first provider with extensive model library and competitive pricing
 
 ### Choosing Between GLM and Synthetic
-**Choose GLM if:**
-- You're on a budget ($3-30/month range)
-- You need heavy usage within 5-hour windows (Pro plan: 600 prompts/5h, Max plan: 2,400 prompts/5h)
-- You want the most cost-effective option for intensive development work
-- Budget recommendation: GLM Pro ($15/month) for heavy 5h window usage
 
-**Choose Synthetic if:**
+> **Pricing Note:** Always check current pricing at [GLM Pricing](https://z.ai/subscribe?ic=CUEFJ9ALMX) and [Synthetic Pricing](https://synthetic.new/?referral=IDyp75aoQpW9YFt) as prices may change.
+
+**Choose GLM Lite ($3/month) if:**
+- You're most developers (this is the sweet spot for majority)
+- You're on a tight budget but want professional AI assistance
+- You have moderate AI usage patterns
+- You want the most cost-effective option
+- **Recommended starting point for most vibecoding workflows**
+
+**Choose GLM Pro ($15/month) if:**
+- You're a heavy user working in intensive 5-hour sessions
+- You need 600 prompts within 5h windows
+- You consistently hit GLM Lite rate limits
+- You work on multiple projects simultaneously with high AI demands
+
+**Choose Synthetic Standard ($20/month) if:**
 - You have a moderate budget (~$20/month)
 - You value model flexibility and want access to 20+ frontier models
 - Privacy is a top concern for your code
-- You have moderately heavy usage spread across 5-hour windows (135 messages/5h on Standard plan)
+- You have moderately heavy usage spread across 5-hour windows (135 messages/5h)
 - You want 3x more messages than Claude's $20 plan
 
 **Budget Summary:**
-- **$0-20/month**: GLM as primary (Lite $3, Pro $15) or Synthetic Standard ($20)
-- **Heavy 5h usage + $15-20 budget**: GLM Pro is optimal
-- **Moderate 5h usage + $20 budget**: Synthetic Standard for flexibility
+- **$0-3/month**: Qwen CLI (free) or GLM Lite ($3) - optimal for most users
+- **$3-15/month**: GLM Lite ($3) for majority, GLM Pro ($15) only if you're a heavy user
+- **$20/month**: Synthetic Standard if you need model variety and privacy focus
+- **$15-20 sweet spot**: GLM Pro ($15) for heavy 5h usage OR Synthetic Standard ($20) for model flexibility
 
 ## Honorable Mentions
 Services I've used but don't recommend for primary development work:

--- a/docs/development-tools/decision-matrix.md
+++ b/docs/development-tools/decision-matrix.md
@@ -80,10 +80,10 @@ Cost-effectiveness = (Features you'll actually use × Reliability) / Total cost
 
 Detailed comparison of AI coding assistants:
 
-| Feature | Qwen CLI | GLM | Claude Code | Cursor |
-|---------|----------|-----|-------------|--------|
-| **Monthly Cost** | $0 | $15 | $200 | $20 |
-| **Annual Cost** | $0 | $180 | $2,400 | $240 |
+| Feature | Qwen CLI | GLM Lite / Pro | Claude Code | Cursor |
+|---------|----------|----------------|-------------|--------|
+| **Monthly Cost** | $0 | $3 / $15 | $200 | $20 |
+| **Annual Cost** | $0 | $36 / $180 | $2,400 | $240 |
 | **Model** | Qwen 2.5 72B | GLM-4-Plus | Claude Sonnet 4 | Multiple |
 | **Local/Remote** | Remote (Factory API) | Remote (GLM API) | Remote (Anthropic) | Remote |
 | **Context Window** | 128k tokens | 128k tokens | 200k tokens | Varies |
@@ -141,41 +141,70 @@ qwen chat "Create a contact form component"
 **Real-world example:**
 > "I built my entire SaaS MVP using Qwen CLI (free). Only upgraded to GLM when I started billing clients and needed faster responses." - Freelancer using this guide
 
-### GLM ($15/month)
+### GLM Coding Plan
+
+> **Pricing Note:** For current GLM pricing and plans, visit [z.ai/subscribe](https://z.ai/subscribe?ic=CUEFJ9ALMX). Prices may change - always check the provider's website for the latest information.
+
+GLM offers multiple tiers to fit different usage patterns. **For most developers, start with Lite.**
+
+#### GLM Lite ($3/month) - **RECOMMENDED FOR MOST USERS**
 
 **Best for:**
-- Freelancers billing clients
-- Developers who want good value
-- Production work needing reliability
-- Projects requiring consistent quality
+- Most vibecoding developers (majority use case)
+- Freelancers building websites and apps
+- Production work with moderate AI usage
+- Cost-conscious professionals
 
 **Pros:**
-- ✅ Affordable ($15/mo)
+- ✅ Very affordable ($3/mo - less than a coffee)
 - ✅ Excellent model (GLM-4-Plus)
-- ✅ Good rate limits
+- ✅ Sufficient for most development workflows
 - ✅ Reliable API
 - ✅ Large context window
-- ✅ Consistent responses
+- ✅ Great value for professional work
 
 **Cons:**
 - ❌ CLI only (no IDE integration)
 - ❌ Requires manual git commands
-- ❌ Limited advanced features
-- ❌ Chinese company (if that matters for your clients)
+- ❌ Limited to Lite tier rate limits
 
 **When to upgrade from Qwen:**
 - You're billing clients and can expense it
-- You hit Qwen's rate limits
 - You need more reliable/faster responses
-- You can justify $15/mo ($0.50/day)
+- You can justify $3/mo ($0.10/day)
 
-**ROI calculation:**
+#### GLM Pro ($15/month) - **FOR HEAVY USERS ONLY**
+
+**Best for:**
+- Heavy users working in 5-hour intensive sessions
+- Developers needing 600 prompts within 5h windows
+- Multiple projects running simultaneously
+- Enterprise-level work with high AI demands
+
+**Pros:**
+- ✅ High rate limits (600 prompts/5h)
+- ✅ Same excellent GLM-4-Plus model
+- ✅ Reliable for intensive workloads
+- ✅ Still affordable compared to alternatives
+
+**Cons:**
+- ❌ Overkill for most developers
+- ❌ 5x the cost of Lite plan
+- ❌ Most users won't hit Lite limits
+
+**When to upgrade from Lite:**
+- You consistently hit Lite rate limits
+- You work in intensive 5h coding sessions
+- You can justify $15/mo for heavy usage
+- ROI calculation shows clear benefit
+
+**ROI calculation (Pro tier):**
 ```
 $15/month = $0.50/day
-If GLM saves you 15 minutes/day
+If GLM Pro saves you 30 minutes/day vs Lite limits
 Your time worth $40/hour
-Savings: (15/60) × $40 = $10/day
-ROI: $10/day - $0.50/day = $9.50/day profit
+Savings: (30/60) × $40 = $20/day
+ROI: $20/day - $0.50/day = $19.50/day profit
 ```
 
 ### Claude Code ($200/month)

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -36,10 +36,11 @@ Vibecoding across five phases—from vibecoder preparation through deployment. T
 - **Commercial Viability**: Yes, can deliver professional websites and applications
 
 ### Budget Option (Professional Grade) - RECOMMENDED
-- **Tools**: Synthetic / GLM subscription + Zed + MCP servers
-- **Cost**: $0-20/month (main recommended range)
+- **Tools**: GLM Lite / Synthetic Standard + Zed + MCP servers
+- **Cost**: $3-20/month (main recommended range)
 - **Capabilities**: Enhanced AI assistance, better integrations
 - **Commercial Viability**: Enterprise-level project delivery
+- **Note**: GLM Lite ($3/mo) sufficient for most users, GLM Pro ($15/mo) only for heavy usage. Check [current GLM pricing](https://z.ai/subscribe?ic=CUEFJ9ALMX)
 
 ### Premium Option
 - **Tools**: Advanced AI providers + premium integrations

--- a/docs/workflow/phase-0-vibecoder-preparation.md
+++ b/docs/workflow/phase-0-vibecoder-preparation.md
@@ -30,23 +30,24 @@ Have in mind that you don't need frontier or State-Of-The-Art tools to deliver c
 - **Total Cost**: $0/month
 
 #### Budget Option (Professional Grade) - RECOMMENDED
-- **Coding Agent**: [Synthetic](../ai-model-providers/synthetic-new.md) subscription or [GLM Coding Plan](../ai-model-providers/glm-coding-plan.md)
+- **Coding Agent**: [GLM Lite](../ai-model-providers/glm-coding-plan.md) ($3/mo - most users) or [Synthetic Standard](../ai-model-providers/synthetic-new.md) ($20/mo - model variety)
 - **IDE**: [Zed](../development-tools/recommended-tools/zed.md) with premium features
 - **Terminal**: [Warp](../development-tools/recommended-tools/warp.md) for enhanced productivity
 - **MCP Servers**: [Context7](../development-tools/mcp-servers/context7-mcp.md) + [DevTools](../development-tools/mcp-servers/devtools-mcp.md)
-- **Total Cost**: $0-20/month (main recommended range for optimal ROI)
+- **Total Cost**: $3-20/month (main recommended range for optimal ROI)
+- **Note**: Start with GLM Lite ($3/mo). Upgrade to GLM Pro ($15/mo) only if you're a heavy user. [Check current pricing](https://z.ai/subscribe?ic=CUEFJ9ALMX)
 
 #### Premium Option
-- **Coding Agent**: Advanced AI providers (GLM Max $30, Synthetic Pro $60)
+- **Coding Agent**: Advanced AI providers (GLM Max, Synthetic Pro $60)
 - **IDE**: Same as budget + additional premium tools
-- **Total Cost**: $30-50/month
-- **When to use**: Heavier workloads or specialized requirements
-- **Note**: Not required for commercial-quality work
+- **Total Cost**: $30-60/month
+- **When to use**: Very heavy workloads or specialized requirements (rare for most developers)
+- **Note**: Not required for commercial-quality work. Check [current pricing](https://z.ai/subscribe?ic=CUEFJ9ALMX) and [Synthetic pricing](https://synthetic.new/?referral=IDyp75aoQpW9YFt)
 
 #### Experimentation Only ($50+/month)
 - **Total Cost**: $50-100+/month
 - **Only recommended if**: You're comfortable with this spend and want to experiment with multiple premium providers
-- **Important**: This range is for experimentation only - stick to $0-20 for optimal ROI
+- **Important**: This range is for experimentation only - stick to $3-20 for optimal ROI
 
 ### Essential Setup Steps
 


### PR DESCRIPTION
Major changes:
- Feature GLM Lite ($3/mo) prominently as recommended for most users
- Clarify GLM Pro ($15/mo) is for heavy users only
- Add pricing disclaimer directing users to z.ai/subscribe
- Fix Synthetic referral link description (clarify $10/$20 discount structure)
- Update budget range from $0-20 to $3-20 to reflect reality
- Add complete dropped tools list to main README

Affected files:
- README.md: Updated Synthetic/GLM descriptions, added dropped tools
- docs/ai-model-providers/README.md: Restructured GLM vs Synthetic comparison
- docs/development-tools/decision-matrix.md: Split GLM into Lite/Pro sections
- docs/workflow/README.md: Updated budget option with GLM Lite focus
- docs/workflow/phase-0-vibecoder-preparation.md: Updated budget tiers with pricing links

This resolves confusion around GLM pricing and ensures users understand:
- GLM Lite ($3) is sufficient for majority of developers
- GLM Pro ($15) only needed for heavy 5h usage (600 prompts)
- Always check provider websites for current pricing